### PR TITLE
Replace broken activate-venv command in Makefile with alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-activate-venv:
-	source .venv/bin/activate
+# alias act="source .venv/bin/activate"
+# alias run-tests="pytest tests"
 
 clean-notebook-outputs:
 	jupyter nbconvert --clear-output --inplace notebooks/*.ipynb


### PR DESCRIPTION
The target used 'source' command which is a shell built-in and not available to make.
Users should activate the virtual environment manually with 'source .venv/bin/activate'.
Created alias:
alias act="source .venv/bin/activate"
alias run-tests="pytest tests"