### PR TITLE
Add prompt template versioning via YAML or registry

### DIFF
--- a/src/api/core/config.py
+++ b/src/api/core/config.py
@@ -14,6 +14,7 @@ class Config(BaseSettings):
     LANGSMITH_ENDPOINT: str
     LANGSMITH_API_KEY: str
     LANGSMITH_PROJECT: str
+    RAG_PROMPT_TEMPLATE_PATH: str = "src/api/rag/prompts/rag_generation.yaml"
 
     model_config = SettingsConfigDict(env_file=".env")
 

--- a/src/api/rag/prompts/rag_generation.yaml
+++ b/src/api/rag/prompts/rag_generation.yaml
@@ -1,0 +1,31 @@
+metadata:
+  name: rag_generation_prompt
+  description: "This prompt is used to generate a response to a question based on the provided context."
+  version: 1.0.0
+prompts:
+  rag_generation: |
+    You are a shopping assistant that can answer questions about the products in stock.
+    You will be given a question and a list of context.
+
+    Instructions:
+    - You need to answer the question based on the provided context only.
+    - In your answer never use word "context", istead refer to it as "available products"
+    - As an output, you need to provide:
+
+    * The answer to the question based on the provided context
+    * The list of the indexes of the chunks that were used to answer the question. Only return return the ones that are used in the answer.
+    * A short description of the item based on the context.
+
+    - The answer to the question should contain detailed information about the products and returned with detailed specifications in bullet points.
+    - Clearly visually separate each product in the answer.
+    - The short description should have the name of the item.
+
+    <OUTPUT JSON SCHEMA>
+    {{ output_json_schema }}
+    </OUTPUT JSON SCHEMA>
+
+    Context:
+    {{ processed_context }}
+
+    Question:
+    {{ question }}

--- a/src/api/rag/retrieval.py
+++ b/src/api/rag/retrieval.py
@@ -8,6 +8,7 @@ from openai import OpenAI
 from typing import List
 import json
 
+from api.rag.utils.utils import prompt_template_config, prompt_template_regstry
 from api.core.config import config
 
 #qdrant_client = QdrantClient(url=f"http://{config.QDRANT_URL}:6333")
@@ -127,31 +128,15 @@ def build_prompt(context, question):
     
     processed_context = process_context(context)
     
-    prompt = f"""
-You are a shopping assistant that can answer questions about the products in stock.
-You will be given a question and a list of context.
-
-Instructions:
-- You need to answer the question based on the provided context only.
-- In your answer never use word "context", istead refer to it as "available products"
-- As an output, you need to provide:
-
-* The answer to the question based on the provided context
-* The list of the indexes of the chunks that were used to answer the question. Only return return the ones that are used in the answer.
-* A short description of the item based on the context.
-
-- The answer to the question should contain detailed information about the products and returned with detailed specifications in bullet points.
-- The short description should have the name of the item.
-
-<OUTPUT_SCHEMA>
-{json.dumps(OUTPUT_SCHEMA, indent=2)}
-</OUTPUT_SCHEMA>
-
-Context:
-{processed_context}
-Question:
-{question}
-"""
+    # prompt_template = prompt_template_config(config.RAG_PROMPT_TEMPLATE_PATH, "rag_generation") # yaml file path and prompt template name
+    prompt_template = prompt_template_regstry("rag-prompt")
+    
+    prompt = prompt_template.render(
+        processed_context=processed_context,
+        question=question,
+        output_json_schema=json.dumps(OUTPUT_SCHEMA, indent=2),
+    )
+    
     return prompt
 
 

--- a/src/api/rag/utils/utils.py
+++ b/src/api/rag/utils/utils.py
@@ -1,0 +1,29 @@
+import yaml
+from jinja2 import Template
+from langsmith import Client
+
+
+# Read the yaml file and return the template
+def prompt_template_config(yaml_file, prompt_key):
+    
+    with open(yaml_file, "r") as f:
+        config = yaml.safe_load(f)    
+    template_content = config["prompts"][prompt_key] # a string
+    template = Template(template_content) # convert the string to jinja template
+    
+    return template
+
+
+# Load from registry
+ls_client = Client()
+def prompt_template_regstry(prompt_name):
+    # get_promt return metadata, pull - template; 0- system, 1 user
+    # returns a string
+    template_content = ls_client.pull_prompt(prompt_name).messages[1].prompt.template 
+    template = Template(template_content) # convert the string to jinja template
+    return template
+
+
+
+
+

--- a/src/chatbot_ui/streamlit_app.py
+++ b/src/chatbot_ui/streamlit_app.py
@@ -4,7 +4,7 @@ import requests
 from src.chatbot_ui.core.config import settings
 
 st.set_page_config(
-    page_title="Ecommerce Assistant",
+    page_title="Amazon AI Assistant",
     layout="wide",
     initial_sidebar_state="expanded",
 )


### PR DESCRIPTION
- Implemented 2 ways to manage and version prompts:
   1) YAML file-based templates (jinja2 template) 
   2) Creating & pulling prompts in from LangSmith prompt registry  
- Updated retrieval.py to build prompts using either of configurable templates
- Remove hardcoded user prompt from build_prompt method